### PR TITLE
chore: .gitignoreで日本語フォントを扱わない

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,7 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Japanese Fonts
+NotoSansJP-Regular SDF.asset
+NotoSansJP-Regular SDF.asset.meta


### PR DESCRIPTION
## 概要

Unityで日本語をフォントを追加する際に、サイズが大きいためGitで共有はしない。
本プロジェクトでは、各自が該当データを手動で追加する。

.gitignoreで
NotoSansJP-Regular SDF.asset
NotoSansJP-Regular SDF.asset.meta
を扱わないように設定